### PR TITLE
Update to loc-less eio

### DIFF
--- a/example/burn.ml
+++ b/example/burn.ml
@@ -2,7 +2,7 @@ open Eio
 
 let woops_sleepy ~clock =
   Switch.run @@ fun sw ->
-  Fiber.fork ~loc:__LOC__ ~sw (fun () ->
+  Fiber.fork ~sw (fun () ->
       (* Woops! Wrong sleep function, we blocked the fiber *)
       traceln "Woops! Blocked by Unix.sleepf";
       Unix.sleepf 5.;
@@ -11,7 +11,7 @@ let woops_sleepy ~clock =
 let spawn ~clock min max =
   Switch.run @@ fun sw ->
   for i = min to max do
-    Fiber.fork ~loc:__LOC__ ~sw (fun () ->
+    Fiber.fork ~sw (fun () ->
         for _i = 0 to max do
           Time.sleep clock 0.2;
           Fiber.yield ()
@@ -25,11 +25,11 @@ let main clock =
   let p, r = Promise.create () in
   Switch.run @@ fun sw ->
   (* A long running task *)
-  Fiber.fork ~loc:__LOC__ ~sw (fun () ->
+  Fiber.fork ~sw (fun () ->
       traceln "stuck waiting :(";
       Promise.await p;
       traceln "Done");
-  Fiber.all ~loc:__LOC__
+  Fiber.all
     [
       (fun () -> spawn ~clock 5 10);
       (fun () -> spawn ~clock 10 30);

--- a/example/burn_domains.ml
+++ b/example/burn_domains.ml
@@ -2,7 +2,7 @@ open Eio
 
 let woops_sleepy ~clock =
   Switch.run @@ fun sw ->
-  Fiber.fork ~loc:__LOC__ ~sw (fun () ->
+  Fiber.fork ~sw (fun () ->
       (* Woops! Wrong sleep function, we blocked the fiber *)
       traceln "Woops! Blocked by Unix.sleepf";
       Unix.sleepf 5.;
@@ -11,7 +11,7 @@ let woops_sleepy ~clock =
 let spawn ~clock min max =
   Switch.run @@ fun sw ->
   for i = min to max do
-    Fiber.fork ~loc:__LOC__ ~sw (fun () ->
+    Fiber.fork ~sw (fun () ->
         for _i = 0 to max do
           Time.sleep clock 0.2;
           Fiber.yield ()
@@ -24,7 +24,7 @@ let spawn ~clock min max =
 let main dom_mgr clock =
   let p, r = Promise.create () in
   (* A long running task *)
-  Fiber.all ~loc:__LOC__
+  Fiber.all
     [
       (fun () -> spawn ~clock 5 10);
       (fun () -> spawn ~clock 10 30);
@@ -32,7 +32,7 @@ let main dom_mgr clock =
         traceln "Spawning domain";
         Eio.Domain_manager.run dom_mgr (fun () ->
             Switch.run @@ fun sw ->
-            Fiber.fork ~loc:__LOC__ ~sw (fun () ->
+            Fiber.fork ~sw (fun () ->
                 traceln "stuck waiting :(";
                 Promise.await p;
                 traceln "Done")));

--- a/example/dune
+++ b/example/dune
@@ -1,3 +1,3 @@
 (executables
  (names main burn burn_domains)
- (libraries eio eio_main unix eio.unix))
+ (libraries astring eio eio_main unix eio.unix))

--- a/example/main.ml
+++ b/example/main.ml
@@ -3,7 +3,7 @@ open Eio
 let spawn ~clock min max =
   Switch.run @@ fun sw ->
   for i = min to max do
-    Fiber.fork ~loc:__LOC__ ~sw (fun () -> Time.sleep clock (float_of_int i));
+    Fiber.fork ~sw (fun () -> Time.sleep clock (float_of_int i));
     Time.sleep clock (float_of_int (max - i))
   done
 
@@ -12,13 +12,11 @@ let main clock =
   let p, r = Promise.create () in
   Switch.run @@ fun sw ->
   (* A long running task *)
-  Fiber.fork ~loc:__LOC__ ~sw (fun () ->
+  Fiber.fork ~sw (fun () ->
       traceln "Waiting";
       Promise.await p;
       traceln "Done");
-  Fiber.both ~loc:__LOC__
-    (fun () -> spawn ~clock 5 10)
-    (fun () -> spawn ~clock 10 30);
+  Fiber.both (fun () -> spawn ~clock 5 10) (fun () -> spawn ~clock 10 30);
   Promise.resolve r ()
 
 let () =


### PR DESCRIPTION
Now Eio uses `Printexc.get_callstack` -- not sure of the performance impacts of that.