### PR TITLE
redirect child process output to /dev/null

### DIFF
--- a/src/bin/meio.ml
+++ b/src/bin/meio.ml
@@ -12,13 +12,15 @@ let run _stdenv exec_args =
       |]
       (Unix.environment ())
   in
+  let dev_null = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o666 in
   let child_pid =
-    Unix.create_process_env executable_filename argsl env Unix.stdin Unix.stdout
-      Unix.stderr
+    Unix.create_process_env executable_filename argsl env Unix.stdin dev_null
+      dev_null
   in
   Unix.sleepf 0.2;
   let handle = (tmp_dir, child_pid) in
   Meio.ui handle;
+  Unix.close dev_null;
   Unix.kill child_pid Sys.sigkill;
   let ring_file =
     Filename.concat tmp_dir (string_of_int child_pid ^ ".events")


### PR DESCRIPTION
When a child process outputs it interferes with the console. So for now the output is redirected to /dev/null. 

At some point we can display it somewhere in the console instead.