### PR TITLE
Precise busy computation / stop counting when fiber is resolved

### DIFF
--- a/src/lib/console.ml
+++ b/src/lib/console.ml
@@ -8,7 +8,7 @@ let prev_now =
   Lwd.var (ts, ts)
 
 let set_prev_now now =
-  let really_old, old = Lwd.peek prev_now in
+  let _, old = Lwd.peek prev_now in
   Lwd.set prev_now (old, now)
 
 let set_selected = function

--- a/src/lib/meio.ml
+++ b/src/lib/meio.ml
@@ -130,8 +130,9 @@ let ui handle =
         | Some (`Switch (v, domain, ts)) ->
             State.switch_to ~id:(v :> int) ~domain ts
         | Some (`Suspend (domain, ts)) -> State.switch_to ~id:(-1) ~domain ts
-        | Some (`Resolved (_v, _, _)) ->
-            () (* XXX: When to do this State.remove_task v ?  *)
+        | Some (`Resolved (v, _, ts)) ->
+            State.resolved (v: int) ts
+          (* XXX: When to do this State.remove_task v ?  *)
         | Some (`Labelled (i, l)) -> State.update_loc (i :> int) l
       done)
     ~tick_period:0.05 ui;

--- a/src/lib/meio.ml
+++ b/src/lib/meio.ml
@@ -127,9 +127,9 @@ let ui handle =
         match Queue.pop q with
         | None -> ()
         | Some (`Created v) -> State.add_tasks v
-        | Some (`Switch (v, domain, _)) ->
-            State.switch_to ~id:(v :> int) ~domain
-        | Some (`Suspend (domain, _)) -> State.switch_to ~id:(-1) ~domain
+        | Some (`Switch (v, domain, ts)) ->
+            State.switch_to ~id:(v :> int) ~domain ts
+        | Some (`Suspend (domain, ts)) -> State.switch_to ~id:(-1) ~domain ts
         | Some (`Resolved (_v, _, _)) ->
             () (* XXX: When to do this State.remove_task v ?  *)
         | Some (`Labelled (i, l)) -> State.update_loc (i :> int) l

--- a/src/lib/state.ml
+++ b/src/lib/state.ml
@@ -11,3 +11,6 @@ let update_loc i id = Task_table.update_loc tasks i id
 let switch_to ~id ~domain ts =
   Task_table.update_active tasks ~id ~domain
     (Runtime_events.Timestamp.to_int64 ts)
+
+let resolved v ts =
+  Task_table.set_resolved tasks v (Runtime_events.Timestamp.to_int64 ts)

--- a/src/lib/state.ml
+++ b/src/lib/state.ml
@@ -1,4 +1,3 @@
-
 (* Mutable State *)
 let tasks = Task_table.create ()
 
@@ -8,4 +7,7 @@ let add_tasks (id, domain, ts) =
 
 let remove_task i = Task_table.remove_by_id tasks i
 let update_loc i id = Task_table.update_loc tasks i id
-let switch_to ~id ~domain = Task_table.update_active tasks ~id ~domain
+
+let switch_to ~id ~domain ts =
+  Task_table.update_active tasks ~id ~domain
+    (Runtime_events.Timestamp.to_int64 ts)

--- a/src/lib/task.ml
+++ b/src/lib/task.ml
@@ -6,17 +6,17 @@ type t = {
   id : int;
   domain : int;
   start : int64;
-  mutable busy : int64 ref list;
+  busy : int64 list;
   mutable info : string list; (* include location *)
   mutable selected : bool;
-  active : bool;
+  active : int64 option;
 }
 
-let get_current_busy t = match t.busy with [] -> 0L | x :: _ -> !x
+let get_current_busy t = match t.busy with [] -> 0L | x :: _ -> x
 let equal a b = a.id = b.id && a.domain = b.domain
 
 let create ~id ~domain start =
-  { id; domain; start; busy = []; info = []; selected = false; active = false }
+  { id; domain; start; busy = []; info = []; selected = false; active = None }
 
 let percentiles =
   [ 25.0; 50.0; 60.0; 70.0; 80.0; 90.0; 95.0; 99.0; 99.9; 99.99 ]
@@ -25,12 +25,11 @@ let max_list =
   List.fold_left (fun max v -> if Int64.compare v max > 0 then v else max) 0L
 
 let make_histogram task =
-  let busy = List.map (fun v -> !v) task.busy in
   let h =
     H.init ~lowest_discernible_value:10 ~highest_trackable_value:10_000_000_000
       ~significant_figures:3
   in
-  List.iter (fun v -> assert (H.record_value h (Int64.to_int v))) busy;
+  List.iter (fun v -> assert (H.record_value h (Int64.to_int v))) task.busy;
   h
 
 let ns_span i = Fmt.(to_to_string uint64_ns_span (Int64.of_int i))

--- a/src/lib/task.ml
+++ b/src/lib/task.ml
@@ -2,6 +2,8 @@ open Nottui
 module W = Nottui_widgets
 module H = Hdr_histogram
 
+type status = Paused | Active of int64 | Resolved of int64
+
 type t = {
   id : int;
   domain : int;
@@ -9,14 +11,14 @@ type t = {
   busy : int64 list;
   mutable info : string list; (* include location *)
   mutable selected : bool;
-  active : int64 option;
+  status : status;
 }
 
 let get_current_busy t = match t.busy with [] -> 0L | x :: _ -> x
 let equal a b = a.id = b.id && a.domain = b.domain
 
 let create ~id ~domain start =
-  { id; domain; start; busy = []; info = []; selected = false; active = None }
+  { id; domain; start; busy = []; info = []; selected = false; status = Paused }
 
 let percentiles =
   [ 25.0; 50.0; 60.0; 70.0; 80.0; 90.0; 95.0; 99.0; 99.9; 99.99 ]

--- a/src/lib/task_table.ml
+++ b/src/lib/task_table.ml
@@ -66,13 +66,19 @@ let update_active { table; _ } ~domain ~id ts =
   map
     (fun t ->
       if Int.equal t.Task.id id && Int.equal t.Task.domain domain then
-        { t with active = Some ts }
+        { t with status = Active ts }
       else if Int.equal t.Task.domain domain then
-        match t.active with
-        | None -> t
-        | Some start ->
-            { t with active = None; busy = Int64.sub ts start :: t.busy }
+        match t.status with
+        | Active start ->
+            { t with status = Paused; busy = Int64.sub ts start :: t.busy }
+        | _ -> t
       else t)
+    (Lwd_table.first table)
+
+let set_resolved { table; _ } id ts =
+  map
+    (fun t ->
+      if Int.equal t.Task.id id then { t with status = Resolved ts } else t)
     (Lwd_table.first table)
 
 let find_sort_row t v = function


### PR DESCRIPTION
* Because the suspend event was not handled, the last fiber before suspension would be considered busy even if it was sleeping.
* Runtime events provide precise timers, we can use them to know when fiber switches happen, it will be more precise then getting the current timestamp when the event is read from the queue. This way, we also avoid using `refresh_active_tasks` which was in charge of incrementing the busy counter of the active fiber. Instead the total busy value is known when the fiber infos are rendered. 
*  When a fiber resolves, the idle value keeps increasing. Instead we can stop the counter when that happens. 

I have also added text colors depending on the fiber state:
- white: active and paused
- bold: active and busy
- gray: resolved 