### PR TITLE
don't keep the list of busy times, instead directly compute the histogram

### DIFF
--- a/src/lib/console.ml
+++ b/src/lib/console.ml
@@ -53,8 +53,7 @@ let resize_uis widths (bg, uis) =
   List.map2 (fun w ui -> Ui.resize ~bg ~w ~pad:gravity_pad ui) widths uis
 
 let render_task now _
-    ({ Task.id; domain; start; loc; name; busy; selected; status; _ } as
-    t) =
+    ({ Task.id; domain; start; loc; name; busy; selected; status; _ } as t) =
   let attr =
     let open Notty.A in
     let fg_attr =
@@ -70,13 +69,13 @@ let render_task now _
   let id = W.int ~attr id in
   let total = Int64.sub now start in
   let active_busy = match status with Active v -> Int64.sub now v | _ -> 0L in
-  let total_busy = List.fold_left Int64.add active_busy busy in
+  let total_busy = Int64.add active_busy (Task.Busy.total busy) in
   let idle = max 0L (Int64.sub total total_busy) in
   let busy = W.string ~attr @@ Fmt.(to_to_string uint64_ns_span total_busy) in
   let idle = W.string ~attr @@ Fmt.(to_to_string uint64_ns_span idle) in
   let loc = W.string ~attr (String.concat "\n" loc) in
   let name = W.string ~attr (String.concat "\n" name) in
-  let entered = W.int ~attr (List.length t.busy) in
+  let entered = W.int ~attr (Task.Busy.count t.busy) in
   [ (attr, [ domain; id; name; busy; idle; entered; loc ]) ]
 
 let ui_monoid_list : (Notty.attr * ui list) list Lwd_utils.monoid =

--- a/src/lib/task.ml
+++ b/src/lib/task.ml
@@ -4,11 +4,41 @@ module H = Hdr_histogram
 
 type status = Paused | Active of int64 | Resolved of int64
 
+module Busy : sig
+  type t
+
+  val make : unit -> t
+  val total : t -> int64
+  val count : t -> int
+  val hist : t -> H.t
+  val add : t -> int64 -> unit
+end = struct
+  type t = { mutable total : int64; mutable count : int; hist : H.t }
+
+  let make () =
+    {
+      total = 0L;
+      count = 0;
+      hist =
+        H.init ~lowest_discernible_value:10
+          ~highest_trackable_value:10_000_000_000 ~significant_figures:3;
+    }
+
+  let total t = t.total
+  let count t = t.count
+  let hist t = t.hist
+
+  let add t value =
+    assert (H.record_value t.hist (Int64.to_int value));
+    t.total <- Int64.add t.total value;
+    t.count <- t.count + 1
+end
+
 type t = {
   id : int;
   domain : int;
   start : int64;
-  busy : int64 list;
+  busy : Busy.t;
   name : string list;
   loc : string list;
   logs : string list;
@@ -16,7 +46,7 @@ type t = {
   status : status;
 }
 
-let get_current_busy t = match t.busy with [] -> 0L | x :: _ -> x
+let get_current_busy t = Busy.total t.busy
 let equal a b = a.id = b.id && a.domain = b.domain
 
 let create ~id ~domain start =
@@ -24,7 +54,7 @@ let create ~id ~domain start =
     id;
     domain;
     start;
-    busy = [];
+    busy = Busy.make ();
     logs = [];
     name = [];
     loc = [];
@@ -38,14 +68,7 @@ let percentiles =
 let max_list =
   List.fold_left (fun max v -> if Int64.compare v max > 0 then v else max) 0L
 
-let make_histogram task =
-  let h =
-    H.init ~lowest_discernible_value:10 ~highest_trackable_value:10_000_000_000
-      ~significant_figures:3
-  in
-  List.iter (fun v -> assert (H.record_value h (Int64.to_int v))) task.busy;
-  h
-
+let make_histogram task = Busy.hist task.busy
 let ns_span i = Fmt.(to_to_string uint64_ns_span (Int64.of_int i))
 
 let ui task =

--- a/src/lib/task_table.ml
+++ b/src/lib/task_table.ml
@@ -20,8 +20,9 @@ let map f row =
     | None -> ()
     | Some row ->
         let next = Lwd_table.next row in
-        let t = f (Option.get (Lwd_table.get row)) in
-        Lwd_table.set row t;
+        let t = Option.get (Lwd_table.get row) in
+        let t' = f t in
+        if t != t' then Lwd_table.set row t';
         loop next
   in
   loop row
@@ -82,7 +83,8 @@ let update_active { table; _ } ~domain ~id ts =
       else if Int.equal t.Task.domain domain then
         match t.status with
         | Active start ->
-            { t with status = Paused; busy = Int64.sub ts start :: t.busy }
+            Task.Busy.add t.busy (Int64.sub ts start);
+            { t with status = Paused }
         | _ -> t
       else t)
     (Lwd_table.first table)


### PR DESCRIPTION
This is useful when the program generates millions of events. Another thing to look at is logs (I currently keep them all). 

Also, trigger updates using `Lwd_table.set` only when the mapper function gives a different value. This might not be the best as there is interior mutability. Maybe the function should return an optional value instead (`Some _` means something has changed, `None` means don't update the row).    